### PR TITLE
WDP230901-20-Save-RWD-mode-in-the-application-state-Viewport

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -3,11 +3,15 @@ import PropTypes from 'prop-types';
 
 import styles from './NewFurniture.module.scss';
 import ProductBox from '../../common/ProductBox/ProductBox';
+import { connect } from 'react-redux';
 
 class NewFurniture extends React.Component {
   state = {
     activePage: 0,
     activeCategory: 'bed',
+    splitPage: true,
+    viewport: this.props.viewport.mode,
+    productsCount: 8,
   };
 
   handlePageChange(newPage) {
@@ -18,12 +22,36 @@ class NewFurniture extends React.Component {
     this.setState({ activeCategory: newCategory });
   }
 
+  componentDidUpdate() {
+    if (this.props.viewport.mode !== this.state.viewport) {
+      const newProductsCount = this.getProductCountToViewport(this.props.viewport.mode);
+
+      this.setState({
+        productsCount: newProductsCount,
+        viewport: this.props.viewport.mode,
+      });
+    }
+  }
+
+  getProductCountToViewport(mode) {
+    switch (mode) {
+      case 'mobile':
+        return 2;
+      case 'tablet':
+        return 3;
+      case 'desktop':
+        return 5;
+      default:
+        return 8;
+    }
+  }
+
   render() {
     const { categories, products } = this.props;
-    const { activeCategory, activePage } = this.state;
+    const { activeCategory, activePage, productsCount } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / 8);
+    const pagesCount = Math.ceil(categoryProducts.length / productsCount);
 
     const dots = [];
     for (let i = 0; i < pagesCount; i++) {
@@ -67,11 +95,13 @@ class NewFurniture extends React.Component {
             </div>
           </div>
           <div className='row'>
-            {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col-3'>
-                <ProductBox {...item} />
-              </div>
-            ))}
+            {categoryProducts
+              .slice(activePage * productsCount, (activePage + 1) * productsCount)
+              .map(item => (
+                <div key={item.id} className='col'>
+                  <ProductBox {...item} />
+                </div>
+              ))}
           </div>
         </div>
       </div>
@@ -81,6 +111,8 @@ class NewFurniture extends React.Component {
 
 NewFurniture.propTypes = {
   children: PropTypes.node,
+  viewport: PropTypes.string,
+  mode: PropTypes.string,
   categories: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
@@ -105,4 +137,8 @@ NewFurniture.defaultProps = {
   products: [],
 };
 
-export default NewFurniture;
+const mapStateToProps = state => ({
+  viewport: state.viewport,
+});
+
+export default connect(mapStateToProps)(NewFurniture);

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -1,16 +1,39 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
+import { setViewport } from '../../../redux/viewportRedux';
+import { useDispatch } from 'react-redux';
 
-const MainLayout = ({ children }) => (
-  <div>
-    <Header />
-    {children}
-    <Footer />
-  </div>
-);
+const MainLayout = ({ children }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const handleViewport = () => {
+      if (window.innerWidth <= 767) {
+        dispatch(setViewport('mobile'));
+      } else if (window.innerWidth <= 1023) {
+        dispatch(setViewport('tablet'));
+      } else if (window.innerWidth > 1023) {
+        dispatch(setViewport('desktop'));
+      }
+    };
+    window.addEventListener('resize', handleViewport);
+    handleViewport();
+    return () => {
+      window.removeEventListener('resize', handleViewport);
+    };
+  });
+
+  return (
+    <div>
+      <Header />
+      {children}
+      <Footer />
+    </div>
+  );
+};
 
 MainLayout.propTypes = {
   children: PropTypes.node,

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -254,6 +254,9 @@ const initialState = {
   cart: {
     products: [],
   },
+  viewport: {
+    mode: '',
+  },
 };
 
 export default initialState;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,12 +4,14 @@ import initialState from './initialState';
 import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
+import viewportReducer from './viewportRedux';
 
 // define reducers
 const reducers = {
   cart: cartReducer,
   categories: categoriesReducer,
   products: productsReducer,
+  viewport: viewportReducer,
 };
 
 // add blank reducers for initial state properties without reducers

--- a/src/redux/viewportRedux.js
+++ b/src/redux/viewportRedux.js
@@ -1,0 +1,18 @@
+// actions
+const createActionName = actionName => `app/viewport/${actionName}`;
+const SET_VIEWPORT = createActionName('SET_VIEWPORT');
+
+// action creators
+export const setViewport = payload => ({ type: SET_VIEWPORT, payload });
+
+const viewportReducer = (statePart = { mode: '' }, action) => {
+  switch (action.type) {
+    case SET_VIEWPORT: {
+      return { mode: action.payload };
+    }
+    default:
+      return statePart;
+  }
+};
+
+export default viewportReducer;


### PR DESCRIPTION
https://projects.kodilla.com/browse/WDP230901-20

- Listener na zmiany szerokości viewportu, żeby na tej podstawie ustawiać w stanie aplikacji aktualny tryb:
* mobile - 2 elementy
* tablet - 3 elementy
* desktop - 5 elementów