### PR TITLE
Bugfix  reg credit card img on big screens and 4 beds in NewFurniture component

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -177,7 +177,7 @@ class NewFurniture extends React.Component {
                 .slice(activePage * productsCount, (activePage + 1) * productsCount)
                 .map(item => (
                   <div key={item.id} className='col-lg-3 col-md-4 col-sm-6 col-xs-12'>
-                    <ProductBox {...item} />
+                    <ProductBox {...item} promoted={false} />
                   </div>
                 ))}
             </div>

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -40,6 +40,10 @@
         display: inline-block;
       }
     }
+
+    img {
+      width: 180px;
+    }
   }
 
   .bottomBar {


### PR DESCRIPTION
- na ekranach o szer ok 800px zdjęcie kart kredytowych w footer "uciekało" poza stronę
- w sekcji NewFurniture produkty które miały w initialState promoted=true wyświetlały się inaczej od pozostałych